### PR TITLE
Toast function 'close' added to programmatically close the toast in a way that allows triggers to occur.

### DIFF
--- a/src/jquery.toast.js
+++ b/src/jquery.toast.js
@@ -312,6 +312,10 @@ if ( typeof Object.create !== 'function' ) {
             this.prepareOptions(options, this.options);
             this.setup();
             this.bindToast();
+        },
+        
+        close: function(options) {
+            this._toastEl.find('.close-jq-toast-single').click();
         }
     };
     
@@ -327,6 +331,10 @@ if ( typeof Object.create !== 'function' ) {
 
             update: function( options ) {
                 toast.update( options );
+            },
+            
+            close: function( ) {
+            	toast.close( );
             }
         }
     };

--- a/src/jquery.toast.js
+++ b/src/jquery.toast.js
@@ -314,7 +314,7 @@ if ( typeof Object.create !== 'function' ) {
             this.bindToast();
         },
         
-        close: function(options) {
+        close: function() {
             this._toastEl.find('.close-jq-toast-single').click();
         }
     };


### PR DESCRIPTION
Toast function 'close' added to programmatically close the toast in a way that allows triggers to occur. The 'reset' function removes the toast from the DOM without invoking any triggers. This request invokes the click function trigger attached on close-jq-toast-single, which will cause the triggers to fire, allowing you to perform functionality provided by beforeHide/afterHidden.